### PR TITLE
Updated navigation service to return an accurate link

### DIFF
--- a/app/services/navigate.service.ts
+++ b/app/services/navigate.service.ts
@@ -18,7 +18,7 @@ export class NavigateService {
     }
 
     static getActionLinkWithParams(action: string, params?: URLSearchParams): string {
-        return "#" + action + (params ? "?" + params.toString() : "");
+        return action + (params ? "?" + params.toString() : "");
     }
 
     static retainOnly(params: URLSearchParams | undefined, retainKeys: string[]): URLSearchParams {

--- a/app/ui/elements/sparql-map.tsx
+++ b/app/ui/elements/sparql-map.tsx
@@ -314,6 +314,7 @@ export class SparqlMap extends React.Component<ISparqlMapProps, ISparqlMapState>
             divViewURI.className = "mapboxPopup-divInfo";
             divViewURI.innerHTML =
                 "<a class='oi oi-info' href='" +
+                "#" +
                 NavigateService.getBrowseLink(properties.uri) +
                 "'></a>";
             popup.appendChild(divViewURI);


### PR DESCRIPTION
Closes #1

Navigation service needed to create links without a '#' in order to let React do its routing magic.
For a link created through traditional HTML (needed for the popup in sparql-map.tsx), which bypasses this routing mechanism, the hash is needed though. A hash has been added there.