### PR TITLE
Added support for resources without label.

### DIFF
--- a/app/services/data-model.ts
+++ b/app/services/data-model.ts
@@ -43,6 +43,10 @@ export class Term {
         }
         return false;
     }
+
+    public static getLocalname(iri: string) {
+        return iri.replace(/.*[\/#:]/, "");
+    }
 }
 
 export class TermBuilder {
@@ -54,11 +58,9 @@ export class TermBuilder {
      * "group_text" etc. instead.
      */
     public static parseFromSparqlRecord(record: SparqlRecord, using: string = "entry"): ITerm {
-        const object: ITerm = {
-            name: getRecordValue(record, using + "_text"),
-            iri: getRecordValue(record, using + "_iri"),
-            icon: getRecordValue(record, using + "_icon")
-        };
-        return object;
+        const iri = getRecordValue(record, using + "_iri");
+        const name = getRecordValue(record, using + "_text") || Term.getLocalname(iri);
+        const icon = getRecordValue(record, using + "_icon");
+        return { name, iri, icon };
     }
 }

--- a/app/ui/pages/browse.page.tsx
+++ b/app/ui/pages/browse.page.tsx
@@ -16,6 +16,7 @@ import { parseUrlQuery } from "app/utils/syntax-helpers";
 import { SparqlResultParser } from "../../services/infrastructure/sparql-result-parser";
 import { ISparqlExecutor } from "../../services/infrastructure/sparql-executor";
 import { Resizable, Enable } from "re-resizable";
+import { Term } from "app/services/data-model";
 
 export interface IBrowsePageState {
     currentTerm?: ITerm;
@@ -73,7 +74,7 @@ export class BrowsePage extends React.Component<IBrowsePageProps, IBrowsePageSta
                 const updatedTerm =
                     result && result.length > 0
                         ? TermBuilder.parseFromSparqlRecord(result[0])
-                        : undefined;
+                        : { iri: term.iri, name: Term.getLocalname(term.iri) };
                 if (updatedTerm && updatedTerm.iri === term.iri) {
                     this.setState({ currentTerm: updatedTerm });
                 }

--- a/app/ui/sections/hierarchy.tsx
+++ b/app/ui/sections/hierarchy.tsx
@@ -10,7 +10,7 @@ import {
     TreeDataLoaderService,
     TreeRecord
 } from "app/services/data-loader/tree-data-loader.service";
-import { ITerm, TermBuilder } from "app/services/data-model";
+import { ITerm, Term, TermBuilder } from "app/services/data-model";
 import { ISparqlExecutor } from "app/services/infrastructure/sparql-executor";
 import { ErrorMessage } from "app/ui/_generic/error-message";
 import { TextItem } from "app/ui/elements/text-item";
@@ -95,7 +95,7 @@ export class Hierarchy extends React.Component<IHierarchyProps, IHierarchyState>
                         <td key={"cell_" + irow + "_" + 0}>
                             {this.renderStubsAndExpander(record)}
                             <TextItem
-                                text={term.name}
+                                text={term.name || Term.getLocalname(term.iri)}
                                 link={term.iri}
                                 icon={term.icon}
                                 highlighted={

--- a/app/ui/sections/information.pane.tsx
+++ b/app/ui/sections/information.pane.tsx
@@ -11,7 +11,7 @@ import { TabMap } from "app/ui/tabs/tab.map";
 import { TabInfo } from "app/ui/tabs/tab.info";
 import { TabInstances } from "app/ui/tabs/tab.instances";
 import { TabRelations } from "app/ui/tabs/tab.relations";
-import { ITerm } from "app/services/data-model";
+import { ITerm, Term } from "app/services/data-model";
 
 interface IInformationPaneState {
     activeTabId: string | undefined;
@@ -155,7 +155,7 @@ export class InformationPane extends React.Component<IInformationPaneProps, IInf
         const tabs: JSX.Element[] = this.getTabs();
         const activeTabId = this.state.activeTabId;
 
-        if (!term || !term.iri || !term.name) {
+        if (!term || !term.iri) {
             return null;
         }
 
@@ -163,8 +163,8 @@ export class InformationPane extends React.Component<IInformationPaneProps, IInf
             <section className="rounded border border-dark">
                 <div>
                     <Nav tabs>
-                        <h3 className="mr-auto">{term.name}</h3>
-                        {tabs.map((tab: JSX.Element, itab: number) => {
+                        <h3 className="mr-auto">{term.name || Term.getLocalname(term.iri)}</h3>
+                        {tabs.map((tab: JSX.Element) => {
                             const tabId = tab.props.config.id;
                             const active = tabId == activeTabId;
                             const onClick = () => {


### PR DESCRIPTION
Closes #3 

Ensured terms without label get a readable name based on the localname of their URI.